### PR TITLE
Fix course module viewed event initialization

### DIFF
--- a/mod/livesonner/classes/event/course_module_viewed.php
+++ b/mod/livesonner/classes/event/course_module_viewed.php
@@ -25,6 +25,14 @@ defined('MOODLE_INTERNAL') || die();
  */
 class course_module_viewed extends \core\event\course_module_viewed {
     /**
+     * Init method.
+     */
+    protected function init() {
+        parent::init();
+        $this->data['objecttable'] = 'livesonner';
+    }
+
+    /**
      * Returns localised event name.
      *
      * @return string


### PR DESCRIPTION
## Summary
- ensure the mod_livesonner course_module_viewed event defines its object table for logging compliance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd34f9e92883288167dfc91b3ddc78