### PR TITLE
Fix completion handling on view page

### DIFF
--- a/mod/livesonner/view.php
+++ b/mod/livesonner/view.php
@@ -98,7 +98,8 @@ $event = \mod_livesonner\event\course_module_viewed::create([
 ]);
 $event->trigger();
 
-completion_info::update_state_by_event($course, $cm, COMPLETION_VIEWED);
+$completion = new completion_info($course);
+$completion->set_module_viewed($cm);
 
 $now = time();
 $remaining = $livesonner->timestart - $now;


### PR DESCRIPTION
## Summary
- instantiate completion_info for the course and mark the module as viewed instead of using the missing update_state_by_event helper

## Testing
- php -l livesonner/view.php

------
https://chatgpt.com/codex/tasks/task_e_68dd37c7e0348328b633d6933591777f