### PR TITLE
Ensure countdown strings are available to AMD module

### DIFF
--- a/mod/livesonner/view.php
+++ b/mod/livesonner/view.php
@@ -124,6 +124,8 @@ if (!empty($livesonner->isfinished)) {
 
 $videohtml = livesonner_render_video($context);
 
+$PAGE->requires->strings_for_js(['countdownmessage'], 'mod_livesonner');
+
 if (empty($livesonner->isfinished) && !$hasstarted) {
     $PAGE->requires->js_call_amd('mod_livesonner/countdown', 'init', [
         $livesonner->timestart,


### PR DESCRIPTION
## Summary
- require the countdown message string for the JavaScript countdown module

## Testing
- php -l mod/livesonner/view.php

------
https://chatgpt.com/codex/tasks/task_e_68dd395bd1b083289158863ce2679c76