### PR TITLE
Open join link in new tab

### DIFF
--- a/mod/livesonner/view.php
+++ b/mod/livesonner/view.php
@@ -159,6 +159,8 @@ echo html_writer::start_tag('div', ['class' => 'container my-5']);
                 $buttonattrs['aria-disabled'] = 'true';
             } else {
                 $buttonattrs['href'] = $buttonurl;
+                $buttonattrs['target'] = '_blank';
+                $buttonattrs['rel'] = 'noopener noreferrer';
             }
 
             echo html_writer::tag('a', $buttonlabel, $buttonattrs);


### PR DESCRIPTION
## Summary
- ensure the Join Class button opens the meeting link in a new browser tab to keep Moodle open
- add rel attribute for security when opening in a new tab

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3ad3563c832893629bd87817dd65